### PR TITLE
Handle IndexedDB errors and close connections

### DIFF
--- a/dist/app.bundle.js
+++ b/dist/app.bundle.js
@@ -769,20 +769,48 @@
       fn(store);
       tx.oncomplete = () => resolve();
       tx.onerror = () => reject(tx.error);
-    })
+    }).finally(() => db.close())
   );
-  var add = (punch) => withStore("readwrite", (store) => store.add(punch));
-  var put = (punch) => withStore("readwrite", (store) => store.put(punch));
-  var remove = (id) => withStore("readwrite", (store) => store.delete(id));
-  var all = () => openDb().then(
-    (db) => new Promise((resolve, reject) => {
-      const tx = db.transaction("punches", "readonly");
-      const store = tx.objectStore("punches");
-      const req = store.getAll();
-      req.onsuccess = () => resolve(req.result || []);
-      req.onerror = () => reject(req.error);
-    })
-  );
+  var add = async (punch) => {
+    try {
+      await withStore("readwrite", (store) => store.add(punch));
+    } catch (err) {
+      ui.toast("Storage request failed");
+      throw err;
+    }
+  };
+  var put = async (punch) => {
+    try {
+      await withStore("readwrite", (store) => store.put(punch));
+    } catch (err) {
+      ui.toast("Storage request failed");
+      throw err;
+    }
+  };
+  var remove = async (id) => {
+    try {
+      await withStore("readwrite", (store) => store.delete(id));
+    } catch (err) {
+      ui.toast("Storage request failed");
+      throw err;
+    }
+  };
+  var all = async () => {
+    try {
+      return await openDb().then(
+        (db) => new Promise((resolve, reject) => {
+          const tx = db.transaction("punches", "readonly");
+          const store = tx.objectStore("punches");
+          const req = store.getAll();
+          req.onsuccess = () => resolve(req.result || []);
+          req.onerror = () => reject(req.error);
+        }).finally(() => db.close())
+      );
+    } catch (err) {
+      ui.toast("Storage request failed");
+      throw err;
+    }
+  };
   var idb = { add, put, remove, all };
 
   // src/actions.js

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,37 +1,68 @@
+import { ui } from './ui.js';
+
 const openDb = () =>
   new Promise((resolve, reject) => {
     const req = indexedDB.open('timeTrackerDB', 1);
-    req.onupgradeneeded = () => req.result.createObjectStore('punches', { keyPath: 'id', autoIncrement: true });
+    req.onupgradeneeded = () =>
+      req.result.createObjectStore('punches', { keyPath: 'id', autoIncrement: true });
     req.onsuccess = () => resolve(req.result);
     req.onerror = () => reject(req.error);
   });
 
 const withStore = (mode, fn) =>
-  openDb().then(
-    (db) =>
-      new Promise((resolve, reject) => {
-        const tx = db.transaction('punches', mode);
-        const store = tx.objectStore('punches');
-        fn(store);
-        tx.oncomplete = () => resolve();
-        tx.onerror = () => reject(tx.error);
-      })
+  openDb().then((db) =>
+    new Promise((resolve, reject) => {
+      const tx = db.transaction('punches', mode);
+      const store = tx.objectStore('punches');
+      fn(store);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    }).finally(() => db.close())
   );
 
-const add = (punch) => withStore('readwrite', (store) => store.add(punch));
-const put = (punch) => withStore('readwrite', (store) => store.put(punch));
-const remove = (id) => withStore('readwrite', (store) => store.delete(id));
-const all = () =>
-  openDb().then(
-    (db) =>
+const add = async (punch) => {
+  try {
+    await withStore('readwrite', (store) => store.add(punch));
+  } catch (err) {
+    ui.toast('Storage request failed');
+    throw err;
+  }
+};
+
+const put = async (punch) => {
+  try {
+    await withStore('readwrite', (store) => store.put(punch));
+  } catch (err) {
+    ui.toast('Storage request failed');
+    throw err;
+  }
+};
+
+const remove = async (id) => {
+  try {
+    await withStore('readwrite', (store) => store.delete(id));
+  } catch (err) {
+    ui.toast('Storage request failed');
+    throw err;
+  }
+};
+
+const all = async () => {
+  try {
+    return await openDb().then((db) =>
       new Promise((resolve, reject) => {
         const tx = db.transaction('punches', 'readonly');
         const store = tx.objectStore('punches');
         const req = store.getAll();
         req.onsuccess = () => resolve(req.result || []);
         req.onerror = () => reject(req.error);
-      })
-  );
+      }).finally(() => db.close())
+    );
+  } catch (err) {
+    ui.toast('Storage request failed');
+    throw err;
+  }
+};
 
 export const idb = { add, put, remove, all };
 


### PR DESCRIPTION
## Summary
- ensure IndexedDB database is closed after each transaction
- surface storage request failures via toast notifications

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8c68251148328be918c609e5e1e65