### PR TITLE
feat: terminal themed timeline and flexible status colors

### DIFF
--- a/dist/app.bundle.js
+++ b/dist/app.bundle.js
@@ -667,9 +667,16 @@
       <td class="status-cell"><div class="status-wrap"><button class="status-btn status-${status}" data-id="${p.id}" aria-label="Status"></button>
         <div class="status-menu" data-id="${p.id}">
           <div class="status-option" data-value="default" title="Default"></div>
-          <div class="status-option" data-value="green" title="Green"></div>
-          <div class="status-option" data-value="yellow" title="Yellow"></div>
-          <div class="status-option" data-value="red" title="Red"></div>
+          <div class="status-option" data-value="green" title="Green (transparent)"></div>
+          <div class="status-option" data-value="green-solid" title="Green"></div>
+          <div class="status-option" data-value="yellow" title="Yellow (transparent)"></div>
+          <div class="status-option" data-value="yellow-solid" title="Yellow"></div>
+          <div class="status-option" data-value="red" title="Red (transparent)"></div>
+          <div class="status-option" data-value="red-solid" title="Red"></div>
+          <div class="status-option" data-value="blue" title="Blue (transparent)"></div>
+          <div class="status-option" data-value="blue-solid" title="Blue"></div>
+          <div class="status-option" data-value="purple" title="Purple (transparent)"></div>
+          <div class="status-option" data-value="purple-solid" title="Purple"></div>
         </div></div></td>
       <td class="cell-start">${time.toLabel(p.start)}</td>
       <td class="cell-end">${time.toLabel(p.end)}</td>

--- a/dist/index.html
+++ b/dist/index.html
@@ -119,9 +119,16 @@
                 <button type="button" class="status-btn status-default" id="modalStatusBtn" aria-label="Status"></button>
                 <div class="status-menu" id="modalStatusMenu">
                   <div class="status-option" data-value="default" title="Default"></div>
-                  <div class="status-option" data-value="green" title="Green"></div>
-                  <div class="status-option" data-value="yellow" title="Yellow"></div>
-                  <div class="status-option" data-value="red" title="Red"></div>
+                  <div class="status-option" data-value="green" title="Green (transparent)"></div>
+                  <div class="status-option" data-value="green-solid" title="Green"></div>
+                  <div class="status-option" data-value="yellow" title="Yellow (transparent)"></div>
+                  <div class="status-option" data-value="yellow-solid" title="Yellow"></div>
+                  <div class="status-option" data-value="red" title="Red (transparent)"></div>
+                  <div class="status-option" data-value="red-solid" title="Red"></div>
+                  <div class="status-option" data-value="blue" title="Blue (transparent)"></div>
+                  <div class="status-option" data-value="blue-solid" title="Blue"></div>
+                  <div class="status-option" data-value="purple" title="Purple (transparent)"></div>
+                  <div class="status-option" data-value="purple-solid" title="Purple"></div>
                 </div>
               </div>
             </div>

--- a/dist/styles.css
+++ b/dist/styles.css
@@ -1,14 +1,14 @@
 /* Extracted from timelinebar.html */
 :root {
-  --bg: #0b1020;
-  --panel: #12182b;
-  --panel-2: #0f1630;
-  --text: #e8ecf1;
-  --muted: #a7b0c0;
-  --brand: #5aa2ff;
-  --brand-2: #86b7ff;
-  --accent: #23d997;
-  --danger: #ff6b6b;
+  --bg: #000;
+  --panel: #000;
+  --panel-2: #001000;
+  --text: #00ff66;
+  --muted: #008c3a;
+  --brand: #00ff66;
+  --brand-2: #00994d;
+  --accent: #00ff66;
+  --danger: #ff3333;
   --shadow: 0 10px 30px rgba(0,0,0,.35);
 }
 
@@ -16,12 +16,23 @@
 html, body { height: 100%; }
 body {
   margin: 0;
-  font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+  font-family: 'Courier New', monospace;
   color: var(--text);
-  background: radial-gradient(1200px 800px at 100% 0%, #0d183b 0%, #0b1020 40%);
+  background: var(--bg);
   display: grid;
   place-items: start center;
   padding: 32px 16px 80px;
+  text-shadow: 0 0 4px rgba(0,255,0,0.7);
+  position: relative;
+}
+
+body::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background: rgba(0,0,0,0.1);
+  backdrop-filter: blur(1px);
 }
 
 .app { width: min(1100px, 96vw); display: grid; gap: 24px; }
@@ -33,7 +44,7 @@ body {
 #dayLabel.clickable { cursor: pointer; display: inline-block; border-bottom: 1px dotted rgba(255,255,255,.25); }
 #dayLabel.clickable:hover { border-bottom-color: rgba(255,255,255,.5); }
 
-.card { background: linear-gradient(180deg, var(--panel), var(--panel-2)); border: 1px solid rgba(255,255,255,.06); border-radius: 16px; box-shadow: var(--shadow); overflow: visible; }
+.card { background: linear-gradient(180deg, var(--panel), var(--panel-2)); border: 1px solid rgba(0,255,102,0.2); border-radius: 16px; box-shadow: var(--shadow); overflow: visible; }
 
 /* Timeline */
 .timeline { padding: 30px 20px; }
@@ -62,13 +73,13 @@ body {
 /* Current time indicator */
 .now-indicator { position: absolute; top: 0; bottom: 0; width: 2px; background: #ffd046; box-shadow: 0 0 0 1px rgba(0,0,0,.25), 0 0 10px rgba(255,208,70,.4); transform: translateX(-50%); pointer-events: none; z-index: 2; }
 
-.ghost { position: absolute; top: 0; bottom: 0; background: linear-gradient(180deg, rgba(90,162,255,.3), rgba(90,162,255,.18)); border-left: 2px dashed var(--brand-2); border-right: 2px dashed var(--brand-2); display: none; pointer-events: none; z-index: 1; }
+.ghost { position: absolute; top: 0; bottom: 0; background: linear-gradient(180deg, rgba(0,255,102,.3), rgba(0,255,102,.18)); border-left: 2px dashed var(--brand-2); border-right: 2px dashed var(--brand-2); display: none; pointer-events: none; z-index: 1; }
 
-.tip { position: absolute; top: -36px; transform: translateX(-50%); background: #0b1227; color: var(--text); border: 1px solid rgba(255,255,255,.18); border-radius: 10px; padding: 4px 8px; font-size: 12px; white-space: nowrap; display: none; pointer-events: none; z-index: 2; box-shadow: var(--shadow); }
+.tip { position: absolute; top: -36px; transform: translateX(-50%); background: #000; color: var(--text); border: 1px solid rgba(0,255,102,0.3); border-radius: 10px; padding: 4px 8px; font-size: 12px; white-space: nowrap; display: none; pointer-events: none; z-index: 2; box-shadow: var(--shadow); }
 .tip-center { top: auto; bottom: -36px; }
 
-.punch { position: absolute; top: 16px; bottom: 16px; border-radius: 10px; background: linear-gradient(180deg, var(--brand), var(--brand-2)); box-shadow: inset 0 0 0 1px rgba(255,255,255,.15), 0 6px 16px rgba(0,0,0,.35); display: block; align-items: center; overflow: hidden; cursor: default; padding-left: 10px; padding-right: 10px; }
-.punch-label { font-weight: 600; font-size: 18px; text-align: center; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; padding: 0 8px; color: #08121f; filter: drop-shadow(0px 0px 4px rgba(255,255,255,1)); display: block; margin: 0 auto; }
+.punch { position: absolute; top: 16px; bottom: 16px; border-radius: 10px; background: rgba(0,255,102,0.15); border: 1px solid rgba(0,255,102,0.6); box-shadow: inset 0 0 0 1px rgba(0,255,102,0.2), 0 6px 16px rgba(0,0,0,.35); display: flex; align-items: center; justify-content: center; overflow: hidden; cursor: default; padding: 0 12px; color: var(--text); }
+.punch-label { font-weight: 600; font-size: 18px; text-align: center; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; padding: 0 8px; color: var(--text); text-shadow: 0 0 4px rgba(0,255,0,0.7); margin: 0; flex: 1; }
 
 /* small indicator for notes inside a punch */
 .punch .note-dot { position: absolute; top: 4px; right: 4px; width: 10px; height: 10px; border-radius: 50%; background: #ffd046; box-shadow: 0 0 0 1px rgba(0,0,0,.35), 0 0 6px rgba(255,208,70,.6); border: 0; cursor: pointer; padding: 0; display: inline-block; z-index: 40; }
@@ -88,15 +99,15 @@ body {
 /* active glow for the edge being resized */
 .punch.resizing-left .handle.left .handle-bar,
 .punch.resizing-right .handle.right .handle-bar {
-  box-shadow: 0 0 0 4px rgba(90,162,255,0.18), inset 0 0 0 2px rgba(90,162,255,0.12);
+  box-shadow: 0 0 0 4px rgba(0,255,102,0.18), inset 0 0 0 2px rgba(0,255,102,0.12);
 }
 
 /* indicate which handle will be grabbed on hover/focus (pre-resize feedback) */
 .handle.left:hover .handle-bar, .handle.left:focus .handle-bar, .handle.left:focus-visible .handle-bar {
-  box-shadow: 0 0 0 4px rgba(90,162,255,0.12), inset 0 0 0 2px rgba(90,162,255,0.08);
+  box-shadow: 0 0 0 4px rgba(0,255,102,0.12), inset 0 0 0 2px rgba(0,255,102,0.08);
 }
 .handle.right:hover .handle-bar, .handle.right:focus .handle-bar, .handle.right:focus-visible .handle-bar {
-  box-shadow: 0 0 0 4px rgba(90,162,255,0.12), inset 0 0 0 2px rgba(90,162,255,0.08);
+  box-shadow: 0 0 0 4px rgba(0,255,102,0.12), inset 0 0 0 2px rgba(0,255,102,0.08);
 }
 
 /* remove default focus outline but keep accessible focus-visible handling */
@@ -130,7 +141,7 @@ body {
 .punch .controls, .label-popper .controls { display: none !important; }
 
 /* Floating popover for full note content */
-.note-popover { position: fixed; max-width: 520px; min-width: 260px; background: #0b1227; color: var(--text); border: 1px solid rgba(255,255,255,.12); border-radius: 12px; box-shadow: var(--shadow); padding: 10px 12px; z-index: 300; }
+.note-popover { position: fixed; max-width: 520px; min-width: 260px; background: #000; color: var(--text); border: 1px solid rgba(0,255,102,0.3); border-radius: 12px; box-shadow: var(--shadow); padding: 10px 12px; z-index: 300; }
 .note-popover .note-content { max-height: 260px; overflow: auto; }
 .note-popover .note-close { position: absolute; top: 6px; right: 6px; appearance: none; border: 0; background: transparent; color: var(--muted); cursor: pointer; font-size: 16px; padding: 4px; border-radius: 8px; }
 .note-popover .note-close:hover { background: rgba(255,255,255,.06); color: var(--text); }
@@ -145,10 +156,32 @@ body {
 tbody tr.is-hovered { background: rgba(255,255,255,.06); }
 
 /* Status coloring for punches */
-.punch.status-green { background: linear-gradient(180deg, rgba(35,217,151,0.25), rgba(35,217,151,0.18)); border-color: rgba(35,217,151,0.6); }
-.punch.status-yellow { background: linear-gradient(180deg, rgba(255,208,70,0.28), rgba(255,208,70,0.20)); border-color: rgba(255,208,70,0.55); }
-.punch.status-red { background: linear-gradient(180deg, rgba(255,107,107,0.28), rgba(255,107,107,0.22)); border-color: rgba(255,107,107,0.65); }
-.punch.status-default { /* keep the default styling; optional subtle tint */ }
+.punch.status-green { background: rgba(0,255,0,0.15); border-color: #00ff00; }
+.punch.status-green .punch-label { color: #00ff00; }
+.punch.status-green-solid { background: #00ff00; border-color: #00ff00; }
+.punch.status-green-solid .punch-label { color: #000; }
+
+.punch.status-yellow { background: rgba(255,255,0,0.15); border-color: #ffff00; }
+.punch.status-yellow .punch-label { color: #ffff00; }
+.punch.status-yellow-solid { background: #ffff00; border-color: #ffff00; }
+.punch.status-yellow-solid .punch-label { color: #000; }
+
+.punch.status-red { background: rgba(255,0,0,0.15); border-color: #ff3333; }
+.punch.status-red .punch-label { color: #ff3333; }
+.punch.status-red-solid { background: #ff3333; border-color: #ff3333; }
+.punch.status-red-solid .punch-label { color: #000; }
+
+.punch.status-blue { background: rgba(0,128,255,0.15); border-color: #0080ff; }
+.punch.status-blue .punch-label { color: #33aaff; }
+.punch.status-blue-solid { background: #0080ff; border-color: #0080ff; }
+.punch.status-blue-solid .punch-label { color: #000; }
+
+.punch.status-purple { background: rgba(170,0,255,0.15); border-color: #aa00ff; }
+.punch.status-purple .punch-label { color: #d066ff; }
+.punch.status-purple-solid { background: #aa00ff; border-color: #aa00ff; }
+.punch.status-purple-solid .punch-label { color: #000; }
+
+.punch.status-default { /* keep the default styling */ }
 
 .help-row { display: flex; justify-content: space-between; align-items: center; padding: 10px 16px 16px; border-top: 1px dashed rgba(255,255,255,.08); color: var(--muted); font-size: 13px; }
 
@@ -158,7 +191,7 @@ tbody tr.is-hovered { background: rgba(255,255,255,.06); }
 .modal .body { padding: 18px; display: grid; gap: 12px; }
 .row { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
 label { font-size: 12px; color: var(--muted); display: block; margin-bottom: 6px; }
-input[type="text"], textarea, input[readonly] { width: 100%; border: 1px solid rgba(255,255,255,.12); background: #0b1227; color: var(--text); border-radius: 10px; padding: 10px 12px; font-size: 14px; }
+input[type="text"], textarea, input[readonly] { width: 100%; border: 1px solid rgba(0,255,102,0.3); background: #000; color: var(--text); border-radius: 10px; padding: 10px 12px; font-size: 14px; }
 textarea { resize: vertical; min-height: 72px; }
 .note-foot { margin-top: 6px; display: flex; gap: 6px; align-items: center; }
 .note-foot a { color: var(--brand-2); text-decoration: none; }
@@ -189,18 +222,32 @@ td.note { color: var(--muted); }
 /* Status selector cell */
 td.status-cell, th.status-cell { padding-left: 10px; padding-right: 10px; width: 40px; }
 .status-wrap { position: relative; }
-.status-btn { appearance: none; width: 18px; height: 18px; border-radius: 4px; border: 1px solid rgba(255,255,255,.18); cursor: pointer; background: rgba(255,255,255,.06); display: inline-block; }
-.status-btn.status-green { background: #19c786; border-color: rgba(25,199,134,0.9); }
-.status-btn.status-yellow { background: #ffd046; border-color: rgba(255,208,70,0.9); }
-.status-btn.status-red { background: #ff6b6b; border-color: rgba(255,107,107,0.9); }
-.status-btn.status-default { background: rgba(255,255,255,.06); }
+.status-btn { appearance: none; width: 18px; height: 18px; border-radius: 4px; border: 1px solid rgba(0,255,102,0.3); cursor: pointer; background: rgba(0,255,102,0.1); display: inline-block; }
+.status-btn.status-green { background: rgba(0,255,0,0.3); border-color: #00ff00; }
+.status-btn.status-green-solid { background: #00ff00; border-color: #00ff00; }
+.status-btn.status-yellow { background: rgba(255,255,0,0.3); border-color: #ffff00; }
+.status-btn.status-yellow-solid { background: #ffff00; border-color: #ffff00; }
+.status-btn.status-red { background: rgba(255,0,0,0.3); border-color: #ff3333; }
+.status-btn.status-red-solid { background: #ff3333; border-color: #ff3333; }
+.status-btn.status-blue { background: rgba(0,128,255,0.3); border-color: #0080ff; }
+.status-btn.status-blue-solid { background: #0080ff; border-color: #0080ff; }
+.status-btn.status-purple { background: rgba(170,0,255,0.3); border-color: #aa00ff; }
+.status-btn.status-purple-solid { background: #aa00ff; border-color: #aa00ff; }
+.status-btn.status-default { background: rgba(0,255,102,0.1); }
 
-.status-menu { position: absolute; top: 24px; left: 0; background: #0b1227; border: 1px solid rgba(255,255,255,.12); border-radius: 8px; padding: 6px; display: none; grid-template-columns: repeat(4, 20px); gap: 6px; box-shadow: var(--shadow); z-index: 200; }
-.status-option { width: 18px; height: 18px; border-radius: 4px; border: 1px solid rgba(255,255,255,.18); cursor: pointer; }
-.status-option[data-value="green"] { background: #19c786; border-color: rgba(25,199,134,0.9); }
-.status-option[data-value="yellow"] { background: #ffd046; border-color: rgba(255,208,70,0.9); }
-.status-option[data-value="red"] { background: #ff6b6b; border-color: rgba(255,107,107,0.9); }
-.status-option[data-value="default"] { background: rgba(255,255,255,.06); }
+.status-menu { position: absolute; top: 24px; left: 0; background: #000; border: 1px solid rgba(0,255,102,0.3); border-radius: 8px; padding: 6px; display: none; grid-template-columns: repeat(4, 20px); gap: 6px; box-shadow: var(--shadow); z-index: 200; }
+.status-option { width: 18px; height: 18px; border-radius: 4px; border: 1px solid rgba(0,255,102,0.3); cursor: pointer; }
+.status-option[data-value="green"] { background: rgba(0,255,0,0.3); border-color: #00ff00; }
+.status-option[data-value="green-solid"] { background: #00ff00; border-color: #00ff00; }
+.status-option[data-value="yellow"] { background: rgba(255,255,0,0.3); border-color: #ffff00; }
+.status-option[data-value="yellow-solid"] { background: #ffff00; border-color: #ffff00; }
+.status-option[data-value="red"] { background: rgba(255,0,0,0.3); border-color: #ff3333; }
+.status-option[data-value="red-solid"] { background: #ff3333; border-color: #ff3333; }
+.status-option[data-value="blue"] { background: rgba(0,128,255,0.3); border-color: #0080ff; }
+.status-option[data-value="blue-solid"] { background: #0080ff; border-color: #0080ff; }
+.status-option[data-value="purple"] { background: rgba(170,0,255,0.3); border-color: #aa00ff; }
+.status-option[data-value="purple-solid"] { background: #aa00ff; border-color: #aa00ff; }
+.status-option[data-value="default"] { background: rgba(0,255,102,0.1); }
 
 /* Open state */
 .status-wrap.open .status-menu { display: grid; }
@@ -227,7 +274,7 @@ tbody tr .row-action { cursor: pointer; }
 .cal-day.other-month { opacity: .5; }
 .cal-day.selected { outline: 2px solid var(--brand-2); outline-offset: 2px; }
 .cal-day.today { outline: 2px solid #ffd046; outline-offset: 2px; }
-.cal-day.has-items { border-color: rgba(90,162,255,0.35); }
+.cal-day.has-items { border-color: rgba(0,255,102,0.35); }
 .cal-num { font-weight: 700; font-size: 12px; color: var(--muted); }
 .cal-meta { position: absolute; right: 8px; bottom: 6px; font-size: 11px; color: var(--muted); }
 

--- a/index.html
+++ b/index.html
@@ -119,9 +119,16 @@
                 <button type="button" class="status-btn status-default" id="modalStatusBtn" aria-label="Status"></button>
                 <div class="status-menu" id="modalStatusMenu">
                   <div class="status-option" data-value="default" title="Default"></div>
-                  <div class="status-option" data-value="green" title="Green"></div>
-                  <div class="status-option" data-value="yellow" title="Yellow"></div>
-                  <div class="status-option" data-value="red" title="Red"></div>
+                  <div class="status-option" data-value="green" title="Green (transparent)"></div>
+                  <div class="status-option" data-value="green-solid" title="Green"></div>
+                  <div class="status-option" data-value="yellow" title="Yellow (transparent)"></div>
+                  <div class="status-option" data-value="yellow-solid" title="Yellow"></div>
+                  <div class="status-option" data-value="red" title="Red (transparent)"></div>
+                  <div class="status-option" data-value="red-solid" title="Red"></div>
+                  <div class="status-option" data-value="blue" title="Blue (transparent)"></div>
+                  <div class="status-option" data-value="blue-solid" title="Blue"></div>
+                  <div class="status-option" data-value="purple" title="Purple (transparent)"></div>
+                  <div class="status-option" data-value="purple-solid" title="Purple"></div>
                 </div>
               </div>
             </div>

--- a/src/ui.js
+++ b/src/ui.js
@@ -336,9 +336,16 @@ function renderTable() {
       <td class="status-cell"><div class="status-wrap"><button class="status-btn status-${status}" data-id="${p.id}" aria-label="Status"></button>
         <div class="status-menu" data-id="${p.id}">
           <div class="status-option" data-value="default" title="Default"></div>
-          <div class="status-option" data-value="green" title="Green"></div>
-          <div class="status-option" data-value="yellow" title="Yellow"></div>
-          <div class="status-option" data-value="red" title="Red"></div>
+          <div class="status-option" data-value="green" title="Green (transparent)"></div>
+          <div class="status-option" data-value="green-solid" title="Green"></div>
+          <div class="status-option" data-value="yellow" title="Yellow (transparent)"></div>
+          <div class="status-option" data-value="yellow-solid" title="Yellow"></div>
+          <div class="status-option" data-value="red" title="Red (transparent)"></div>
+          <div class="status-option" data-value="red-solid" title="Red"></div>
+          <div class="status-option" data-value="blue" title="Blue (transparent)"></div>
+          <div class="status-option" data-value="blue-solid" title="Blue"></div>
+          <div class="status-option" data-value="purple" title="Purple (transparent)"></div>
+          <div class="status-option" data-value="purple-solid" title="Purple"></div>
         </div></div></td>
       <td class="cell-start">${time.toLabel(p.start)}</td>
       <td class="cell-end">${time.toLabel(p.end)}</td>

--- a/styles.css
+++ b/styles.css
@@ -1,14 +1,14 @@
 /* Extracted from timelinebar.html */
 :root {
-  --bg: #0b1020;
-  --panel: #12182b;
-  --panel-2: #0f1630;
-  --text: #e8ecf1;
-  --muted: #a7b0c0;
-  --brand: #5aa2ff;
-  --brand-2: #86b7ff;
-  --accent: #23d997;
-  --danger: #ff6b6b;
+  --bg: #000;
+  --panel: #000;
+  --panel-2: #001000;
+  --text: #00ff66;
+  --muted: #008c3a;
+  --brand: #00ff66;
+  --brand-2: #00994d;
+  --accent: #00ff66;
+  --danger: #ff3333;
   --shadow: 0 10px 30px rgba(0,0,0,.35);
 }
 
@@ -16,12 +16,23 @@
 html, body { height: 100%; }
 body {
   margin: 0;
-  font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+  font-family: 'Courier New', monospace;
   color: var(--text);
-  background: radial-gradient(1200px 800px at 100% 0%, #0d183b 0%, #0b1020 40%);
+  background: var(--bg);
   display: grid;
   place-items: start center;
   padding: 32px 16px 80px;
+  text-shadow: 0 0 4px rgba(0,255,0,0.7);
+  position: relative;
+}
+
+body::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background: rgba(0,0,0,0.1);
+  backdrop-filter: blur(1px);
 }
 
 .app { width: min(1100px, 96vw); display: grid; gap: 24px; }
@@ -33,7 +44,7 @@ body {
 #dayLabel.clickable { cursor: pointer; display: inline-block; border-bottom: 1px dotted rgba(255,255,255,.25); }
 #dayLabel.clickable:hover { border-bottom-color: rgba(255,255,255,.5); }
 
-.card { background: linear-gradient(180deg, var(--panel), var(--panel-2)); border: 1px solid rgba(255,255,255,.06); border-radius: 16px; box-shadow: var(--shadow); overflow: visible; }
+.card { background: linear-gradient(180deg, var(--panel), var(--panel-2)); border: 1px solid rgba(0,255,102,0.2); border-radius: 16px; box-shadow: var(--shadow); overflow: visible; }
 
 /* Timeline */
 .timeline { padding: 30px 20px; }
@@ -62,13 +73,13 @@ body {
 /* Current time indicator */
 .now-indicator { position: absolute; top: 0; bottom: 0; width: 2px; background: #ffd046; box-shadow: 0 0 0 1px rgba(0,0,0,.25), 0 0 10px rgba(255,208,70,.4); transform: translateX(-50%); pointer-events: none; z-index: 2; }
 
-.ghost { position: absolute; top: 0; bottom: 0; background: linear-gradient(180deg, rgba(90,162,255,.3), rgba(90,162,255,.18)); border-left: 2px dashed var(--brand-2); border-right: 2px dashed var(--brand-2); display: none; pointer-events: none; z-index: 1; }
+.ghost { position: absolute; top: 0; bottom: 0; background: linear-gradient(180deg, rgba(0,255,102,.3), rgba(0,255,102,.18)); border-left: 2px dashed var(--brand-2); border-right: 2px dashed var(--brand-2); display: none; pointer-events: none; z-index: 1; }
 
-.tip { position: absolute; top: -36px; transform: translateX(-50%); background: #0b1227; color: var(--text); border: 1px solid rgba(255,255,255,.18); border-radius: 10px; padding: 4px 8px; font-size: 12px; white-space: nowrap; display: none; pointer-events: none; z-index: 2; box-shadow: var(--shadow); }
+.tip { position: absolute; top: -36px; transform: translateX(-50%); background: #000; color: var(--text); border: 1px solid rgba(0,255,102,0.3); border-radius: 10px; padding: 4px 8px; font-size: 12px; white-space: nowrap; display: none; pointer-events: none; z-index: 2; box-shadow: var(--shadow); }
 .tip-center { top: auto; bottom: -36px; }
 
-.punch { position: absolute; top: 16px; bottom: 16px; border-radius: 10px; background: linear-gradient(180deg, var(--brand), var(--brand-2)); box-shadow: inset 0 0 0 1px rgba(255,255,255,.15), 0 6px 16px rgba(0,0,0,.35); display: block; align-items: center; overflow: hidden; cursor: default; padding-left: 10px; padding-right: 10px; }
-.punch-label { font-weight: 600; font-size: 18px; text-align: center; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; padding: 0 8px; color: #08121f; filter: drop-shadow(0px 0px 4px rgba(255,255,255,1)); display: block; margin: 0 auto; }
+.punch { position: absolute; top: 16px; bottom: 16px; border-radius: 10px; background: rgba(0,255,102,0.15); border: 1px solid rgba(0,255,102,0.6); box-shadow: inset 0 0 0 1px rgba(0,255,102,0.2), 0 6px 16px rgba(0,0,0,.35); display: flex; align-items: center; justify-content: center; overflow: hidden; cursor: default; padding: 0 12px; color: var(--text); }
+.punch-label { font-weight: 600; font-size: 18px; text-align: center; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; padding: 0 8px; color: var(--text); text-shadow: 0 0 4px rgba(0,255,0,0.7); margin: 0; flex: 1; }
 
 /* small indicator for notes inside a punch */
 .punch .note-dot { position: absolute; top: 4px; right: 4px; width: 10px; height: 10px; border-radius: 50%; background: #ffd046; box-shadow: 0 0 0 1px rgba(0,0,0,.35), 0 0 6px rgba(255,208,70,.6); border: 0; cursor: pointer; padding: 0; display: inline-block; z-index: 40; }
@@ -88,15 +99,15 @@ body {
 /* active glow for the edge being resized */
 .punch.resizing-left .handle.left .handle-bar,
 .punch.resizing-right .handle.right .handle-bar {
-  box-shadow: 0 0 0 4px rgba(90,162,255,0.18), inset 0 0 0 2px rgba(90,162,255,0.12);
+  box-shadow: 0 0 0 4px rgba(0,255,102,0.18), inset 0 0 0 2px rgba(0,255,102,0.12);
 }
 
 /* indicate which handle will be grabbed on hover/focus (pre-resize feedback) */
 .handle.left:hover .handle-bar, .handle.left:focus .handle-bar, .handle.left:focus-visible .handle-bar {
-  box-shadow: 0 0 0 4px rgba(90,162,255,0.12), inset 0 0 0 2px rgba(90,162,255,0.08);
+  box-shadow: 0 0 0 4px rgba(0,255,102,0.12), inset 0 0 0 2px rgba(0,255,102,0.08);
 }
 .handle.right:hover .handle-bar, .handle.right:focus .handle-bar, .handle.right:focus-visible .handle-bar {
-  box-shadow: 0 0 0 4px rgba(90,162,255,0.12), inset 0 0 0 2px rgba(90,162,255,0.08);
+  box-shadow: 0 0 0 4px rgba(0,255,102,0.12), inset 0 0 0 2px rgba(0,255,102,0.08);
 }
 
 /* remove default focus outline but keep accessible focus-visible handling */
@@ -130,7 +141,7 @@ body {
 .punch .controls, .label-popper .controls { display: none !important; }
 
 /* Floating popover for full note content */
-.note-popover { position: fixed; max-width: 520px; min-width: 260px; background: #0b1227; color: var(--text); border: 1px solid rgba(255,255,255,.12); border-radius: 12px; box-shadow: var(--shadow); padding: 10px 12px; z-index: 300; }
+.note-popover { position: fixed; max-width: 520px; min-width: 260px; background: #000; color: var(--text); border: 1px solid rgba(0,255,102,0.3); border-radius: 12px; box-shadow: var(--shadow); padding: 10px 12px; z-index: 300; }
 .note-popover .note-content { max-height: 260px; overflow: auto; }
 .note-popover .note-close { position: absolute; top: 6px; right: 6px; appearance: none; border: 0; background: transparent; color: var(--muted); cursor: pointer; font-size: 16px; padding: 4px; border-radius: 8px; }
 .note-popover .note-close:hover { background: rgba(255,255,255,.06); color: var(--text); }
@@ -145,10 +156,32 @@ body {
 tbody tr.is-hovered { background: rgba(255,255,255,.06); }
 
 /* Status coloring for punches */
-.punch.status-green { background: linear-gradient(180deg, rgba(35,217,151,0.25), rgba(35,217,151,0.18)); border-color: rgba(35,217,151,0.6); }
-.punch.status-yellow { background: linear-gradient(180deg, rgba(255,208,70,0.28), rgba(255,208,70,0.20)); border-color: rgba(255,208,70,0.55); }
-.punch.status-red { background: linear-gradient(180deg, rgba(255,107,107,0.28), rgba(255,107,107,0.22)); border-color: rgba(255,107,107,0.65); }
-.punch.status-default { /* keep the default styling; optional subtle tint */ }
+.punch.status-green { background: rgba(0,255,0,0.15); border-color: #00ff00; }
+.punch.status-green .punch-label { color: #00ff00; }
+.punch.status-green-solid { background: #00ff00; border-color: #00ff00; }
+.punch.status-green-solid .punch-label { color: #000; }
+
+.punch.status-yellow { background: rgba(255,255,0,0.15); border-color: #ffff00; }
+.punch.status-yellow .punch-label { color: #ffff00; }
+.punch.status-yellow-solid { background: #ffff00; border-color: #ffff00; }
+.punch.status-yellow-solid .punch-label { color: #000; }
+
+.punch.status-red { background: rgba(255,0,0,0.15); border-color: #ff3333; }
+.punch.status-red .punch-label { color: #ff3333; }
+.punch.status-red-solid { background: #ff3333; border-color: #ff3333; }
+.punch.status-red-solid .punch-label { color: #000; }
+
+.punch.status-blue { background: rgba(0,128,255,0.15); border-color: #0080ff; }
+.punch.status-blue .punch-label { color: #33aaff; }
+.punch.status-blue-solid { background: #0080ff; border-color: #0080ff; }
+.punch.status-blue-solid .punch-label { color: #000; }
+
+.punch.status-purple { background: rgba(170,0,255,0.15); border-color: #aa00ff; }
+.punch.status-purple .punch-label { color: #d066ff; }
+.punch.status-purple-solid { background: #aa00ff; border-color: #aa00ff; }
+.punch.status-purple-solid .punch-label { color: #000; }
+
+.punch.status-default { /* keep the default styling */ }
 
 .help-row { display: flex; justify-content: space-between; align-items: center; padding: 10px 16px 16px; border-top: 1px dashed rgba(255,255,255,.08); color: var(--muted); font-size: 13px; }
 
@@ -158,7 +191,7 @@ tbody tr.is-hovered { background: rgba(255,255,255,.06); }
 .modal .body { padding: 18px; display: grid; gap: 12px; }
 .row { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
 label { font-size: 12px; color: var(--muted); display: block; margin-bottom: 6px; }
-input[type="text"], textarea, input[readonly] { width: 100%; border: 1px solid rgba(255,255,255,.12); background: #0b1227; color: var(--text); border-radius: 10px; padding: 10px 12px; font-size: 14px; }
+input[type="text"], textarea, input[readonly] { width: 100%; border: 1px solid rgba(0,255,102,0.3); background: #000; color: var(--text); border-radius: 10px; padding: 10px 12px; font-size: 14px; }
 textarea { resize: vertical; min-height: 72px; }
 .note-foot { margin-top: 6px; display: flex; gap: 6px; align-items: center; }
 .note-foot a { color: var(--brand-2); text-decoration: none; }
@@ -189,18 +222,32 @@ td.note { color: var(--muted); }
 /* Status selector cell */
 td.status-cell, th.status-cell { padding-left: 10px; padding-right: 10px; width: 40px; }
 .status-wrap { position: relative; }
-.status-btn { appearance: none; width: 18px; height: 18px; border-radius: 4px; border: 1px solid rgba(255,255,255,.18); cursor: pointer; background: rgba(255,255,255,.06); display: inline-block; }
-.status-btn.status-green { background: #19c786; border-color: rgba(25,199,134,0.9); }
-.status-btn.status-yellow { background: #ffd046; border-color: rgba(255,208,70,0.9); }
-.status-btn.status-red { background: #ff6b6b; border-color: rgba(255,107,107,0.9); }
-.status-btn.status-default { background: rgba(255,255,255,.06); }
+.status-btn { appearance: none; width: 18px; height: 18px; border-radius: 4px; border: 1px solid rgba(0,255,102,0.3); cursor: pointer; background: rgba(0,255,102,0.1); display: inline-block; }
+.status-btn.status-green { background: rgba(0,255,0,0.3); border-color: #00ff00; }
+.status-btn.status-green-solid { background: #00ff00; border-color: #00ff00; }
+.status-btn.status-yellow { background: rgba(255,255,0,0.3); border-color: #ffff00; }
+.status-btn.status-yellow-solid { background: #ffff00; border-color: #ffff00; }
+.status-btn.status-red { background: rgba(255,0,0,0.3); border-color: #ff3333; }
+.status-btn.status-red-solid { background: #ff3333; border-color: #ff3333; }
+.status-btn.status-blue { background: rgba(0,128,255,0.3); border-color: #0080ff; }
+.status-btn.status-blue-solid { background: #0080ff; border-color: #0080ff; }
+.status-btn.status-purple { background: rgba(170,0,255,0.3); border-color: #aa00ff; }
+.status-btn.status-purple-solid { background: #aa00ff; border-color: #aa00ff; }
+.status-btn.status-default { background: rgba(0,255,102,0.1); }
 
-.status-menu { position: absolute; top: 24px; left: 0; background: #0b1227; border: 1px solid rgba(255,255,255,.12); border-radius: 8px; padding: 6px; display: none; grid-template-columns: repeat(4, 20px); gap: 6px; box-shadow: var(--shadow); z-index: 200; }
-.status-option { width: 18px; height: 18px; border-radius: 4px; border: 1px solid rgba(255,255,255,.18); cursor: pointer; }
-.status-option[data-value="green"] { background: #19c786; border-color: rgba(25,199,134,0.9); }
-.status-option[data-value="yellow"] { background: #ffd046; border-color: rgba(255,208,70,0.9); }
-.status-option[data-value="red"] { background: #ff6b6b; border-color: rgba(255,107,107,0.9); }
-.status-option[data-value="default"] { background: rgba(255,255,255,.06); }
+.status-menu { position: absolute; top: 24px; left: 0; background: #000; border: 1px solid rgba(0,255,102,0.3); border-radius: 8px; padding: 6px; display: none; grid-template-columns: repeat(4, 20px); gap: 6px; box-shadow: var(--shadow); z-index: 200; }
+.status-option { width: 18px; height: 18px; border-radius: 4px; border: 1px solid rgba(0,255,102,0.3); cursor: pointer; }
+.status-option[data-value="green"] { background: rgba(0,255,0,0.3); border-color: #00ff00; }
+.status-option[data-value="green-solid"] { background: #00ff00; border-color: #00ff00; }
+.status-option[data-value="yellow"] { background: rgba(255,255,0,0.3); border-color: #ffff00; }
+.status-option[data-value="yellow-solid"] { background: #ffff00; border-color: #ffff00; }
+.status-option[data-value="red"] { background: rgba(255,0,0,0.3); border-color: #ff3333; }
+.status-option[data-value="red-solid"] { background: #ff3333; border-color: #ff3333; }
+.status-option[data-value="blue"] { background: rgba(0,128,255,0.3); border-color: #0080ff; }
+.status-option[data-value="blue-solid"] { background: #0080ff; border-color: #0080ff; }
+.status-option[data-value="purple"] { background: rgba(170,0,255,0.3); border-color: #aa00ff; }
+.status-option[data-value="purple-solid"] { background: #aa00ff; border-color: #aa00ff; }
+.status-option[data-value="default"] { background: rgba(0,255,102,0.1); }
 
 /* Open state */
 .status-wrap.open .status-menu { display: grid; }
@@ -227,7 +274,7 @@ tbody tr .row-action { cursor: pointer; }
 .cal-day.other-month { opacity: .5; }
 .cal-day.selected { outline: 2px solid var(--brand-2); outline-offset: 2px; }
 .cal-day.today { outline: 2px solid #ffd046; outline-offset: 2px; }
-.cal-day.has-items { border-color: rgba(90,162,255,0.35); }
+.cal-day.has-items { border-color: rgba(0,255,102,0.35); }
 .cal-num { font-weight: 700; font-size: 12px; color: var(--muted); }
 .cal-meta { position: absolute; right: 8px; bottom: 6px; font-size: 11px; color: var(--muted); }
 


### PR DESCRIPTION
## Summary
- center time entry labels and restyle default bars
- switch interface to green-on-black terminal style with screen blur
- expand status selector with solid and transparent options for multiple colors

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b90228d6b883289e97f4cbca057b68